### PR TITLE
#3857 AITバージョンアップ(2025年2月) eval_processcheck_problem_domain_analysis

### DIFF
--- a/deploy/container/dockerfile
+++ b/deploy/container/dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.13-slim-bullseye
+FROM python:3.10.16-slim-bullseye
 LABEL maintainer="AIST"
 
 ENV ROOT_USER=root

--- a/deploy/container/repository/ait.manifest.json
+++ b/deploy/container/repository/ait.manifest.json
@@ -2,7 +2,7 @@
   "name": "eval_processcheck_problem_domain_analysis",
   "description": "機械学習品質マネジメントガイドライン第三版に従って、機械学習利用システムに用いるデータセットが問題領域分析の十分性を満たしているかをチェックリスト方式で審査する。チェックリストはhttps://github.com/aistairc/Qunomon_AIT_eval_processcheck_problem_domain_analysisからダウンロードできる。",
   "source_repository": "https://github.com/aistairc/Qunomon_AIT_eval_processcheck_problem_domain_analysis",
-  "version": "0.3",
+  "version": "0.4",
   "quality": "https://ait-hub.pj.aist.go.jp/ait-hub/api/0.0.1/qualityDimensions/機械学習品質マネジメントガイドライン第三版/A-1問題領域分析の十分性",
   "keywords": [
     "checklist,sufficiency of problem domain"

--- a/deploy/container/repository/my_ait.py
+++ b/deploy/container/repository/my_ait.py
@@ -85,12 +85,13 @@ if not is_ait_launch:
 
 # #### #3-2 [required]
 
-# In[4]:
+# In[1]:
 
 
 if not is_ait_launch:
     requirements_generator.add_package('pandas','2.2.3')
-    requirements_generator.add_package('matplotlib','3.9.4')
+    requirements_generator.add_package('numpy','2.2.3')
+    requirements_generator.add_package('matplotlib','3.10.0')
 
 
 # #### #3-3 [uneditable]
@@ -161,7 +162,7 @@ if not is_ait_launch:
      manifest_genenerator.set_ait_description('機械学習品質マネジメントガイドライン第三版に従って、機械学習利用システムに用いるデータセットが問題領域分析の十分性を満たしているかをチェックリスト方式で審査する。'
                                               'チェックリストはhttps://github.com/aistairc/Qunomon_AIT_eval_processcheck_problem_domain_analysisからダウンロードできる。')
      manifest_genenerator.set_ait_source_repository('https://github.com/aistairc/Qunomon_AIT_eval_processcheck_problem_domain_analysis')
-     manifest_genenerator.set_ait_version('0.3')
+     manifest_genenerator.set_ait_version('0.4')
      manifest_genenerator.add_ait_keywords('checklist,sufficiency of problem domain')
      manifest_genenerator.set_ait_quality('https://ait-hub.pj.aist.go.jp/ait-hub/api/0.0.1/qualityDimensions/機械学習品質マネジメントガイドライン第三版/A-1問題領域分析の十分性')
      inventory_requirement_checklist = manifest_genenerator.format_ait_inventory_requirement(format_=['csv'])

--- a/deploy/container/repository/requirements.txt
+++ b/deploy/container/repository/requirements.txt
@@ -1,3 +1,4 @@
 pandas==2.2.3
-matplotlib==3.9.4
+numpy==2.2.3
+matplotlib==3.10.0
 ./ait_sdk-0.1.24-py3-none-any.whl

--- a/develop/ait.manifest.json
+++ b/develop/ait.manifest.json
@@ -2,7 +2,7 @@
   "name": "eval_processcheck_problem_domain_analysis",
   "description": "機械学習品質マネジメントガイドライン第三版に従って、機械学習利用システムに用いるデータセットが問題領域分析の十分性を満たしているかをチェックリスト方式で審査する。チェックリストはhttps://github.com/aistairc/Qunomon_AIT_eval_processcheck_problem_domain_analysisからダウンロードできる。",
   "source_repository": "https://github.com/aistairc/Qunomon_AIT_eval_processcheck_problem_domain_analysis",
-  "version": "0.3",
+  "version": "0.4",
   "quality": "https://ait-hub.pj.aist.go.jp/ait-hub/api/0.0.1/qualityDimensions/機械学習品質マネジメントガイドライン第三版/A-1問題領域分析の十分性",
   "keywords": [
     "checklist,sufficiency of problem domain"

--- a/develop/my_ait.ipynb
+++ b/develop/my_ait.ipynb
@@ -147,8 +147,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
-      "\u001b[0m\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[0m\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
       "\u001b[0m"
      ]
     }
@@ -224,7 +224,8 @@
    "source": [
     "if not is_ait_launch:\n",
     "    requirements_generator.add_package('pandas','2.2.3')\n",
-    "    requirements_generator.add_package('matplotlib','3.9.4')"
+    "    requirements_generator.add_package('numpy','2.2.3')\n",
+    "    requirements_generator.add_package('matplotlib','3.10.0')"
    ]
   },
   {
@@ -249,9 +250,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-      "jupyter-server 2.15.0 requires nbformat>=5.3.0, but you have nbformat 5.2.0 which is incompatible.\u001b[0m\u001b[31m\n",
-      "\u001b[0m\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
       "\u001b[0m"
      ]
     }
@@ -375,7 +374,7 @@
     "     manifest_genenerator.set_ait_description('機械学習品質マネジメントガイドライン第三版に従って、機械学習利用システムに用いるデータセットが問題領域分析の十分性を満たしているかをチェックリスト方式で審査する。'\n",
     "                                              'チェックリストはhttps://github.com/aistairc/Qunomon_AIT_eval_processcheck_problem_domain_analysisからダウンロードできる。')\n",
     "     manifest_genenerator.set_ait_source_repository('https://github.com/aistairc/Qunomon_AIT_eval_processcheck_problem_domain_analysis')\n",
-    "     manifest_genenerator.set_ait_version('0.3')\n",
+    "     manifest_genenerator.set_ait_version('0.4')\n",
     "     manifest_genenerator.add_ait_keywords('checklist,sufficiency of problem domain')\n",
     "     manifest_genenerator.set_ait_quality('https://ait-hub.pj.aist.go.jp/ait-hub/api/0.0.1/qualityDimensions/機械学習品質マネジメントガイドライン第三版/A-1問題領域分析の十分性')\n",
     "     inventory_requirement_checklist = manifest_genenerator.format_ait_inventory_requirement(format_=['csv'])\n",
@@ -879,7 +878,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.16"
   },
   "vscode": {
    "interpreter": {

--- a/tool/docker/jupyter/dockerfile
+++ b/tool/docker/jupyter/dockerfile
@@ -1,5 +1,5 @@
 # python3をベースにする
-FROM python:3.9.13
+FROM python:3.10.16
 
 RUN apt-get update && apt-get install -y \
     curl \


### PR DESCRIPTION
qai-testbedと揃えるため、
requirements_generator.add_package('numpy','2.2.3')を追加

python3.9.13 → 3.10.16
matplotlib3.9.4 → 3.10.0